### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Welcome to the jsGameWiki!
+# Welcome to the jsGameWiki!
 This is the brain for game programming with html5/canvas/javascript. 
 
 I'm trying to structure helpful sources like eBooks, videos, blogs, articles, presentations...
@@ -32,7 +32,7 @@ In case you want to contribute, be my guest! Here is a place for people who want
 * [Javascript Games](#javascript-games) - for inspiration
 * [Graphics + Sound](#graphics-and-sound) - some tools for graphics + sound
 
-##Part II - Game Related
+## Part II - Game Related
 * [Learning / Tutorials (HTML5 / CSS / Javascript / Gaming](#tutorial)
 * [HTML5 API / Standards / Specifications](#standard-api)
 * HTML5
@@ -51,8 +51,8 @@ In case you want to contribute, be my guest! Here is a place for people who want
 
 
 
-##<a name="game-tutorials">Game Tutorials</a>
-###Javascript - Canvas
+## <a name="game-tutorials">Game Tutorials</a>
+### Javascript - Canvas
 * [Pacman](http://www.jeffreybiles.com/build-pacman) - book about hwo to build pacman with ES6/Ember.js
 * [Space Shooter](http://www.html5rocks.com/tutorials/canvas/notearsgame/)
 * [Developing a Spaceshooter by Mozilla](http://hacks.mozilla.org/2012/03/developing-a-simple-html5-space-shooter/) - source + summary of development for a space shooter
@@ -77,20 +77,20 @@ In case you want to contribute, be my guest! Here is a place for people who want
 * [Angry Birds Clone] (http://training.bocoup.com/screencasts/make-your-own-angry-birds/)
 * [BomberMan Clone] (http://www.yusufaytas.com/implementing-html5-bomberman/)
 
-###actionscript
+### actionscript
 because actionscript is very similar to javascript. you can definitely take away some concepts.
 
 * [Tile Based Games](http://www.tonypa.pri.ee/tbw/start.html)
 
-###how to start
+### how to start
 * [Where should I start to learn game development](https://www.quora.com/Where-should-I-start-to-learn-game-development)
 
 
 
 
 
-##<a name="game-blogs">Game Blogs</a>
-###Blogs about gaming
+## <a name="game-blogs">Game Blogs</a>
+### Blogs about gaming
 * [Blog of Rob Hawkes](http://rawkes.com/) - experiments, talks, book, posts
 * [Blog of glacialflame](http://glacialflame.com/) - articles about isometric games
 * [Blog of That Guy](http://that-guy.net/articles/) - nice article serie about tile game engine
@@ -106,12 +106,12 @@ because actionscript is very similar to javascript. you can definitely take away
 * [Ray Wenderlich](http://raywenderlich.com) - GameDev programming tutorials and articles
 * [Composition of Tools by Andre Schmitz](https://html5-game-development.zeef.com/andre.antonio.schmitz) - A lot of tools, engines, games for js game programming
 
-###Blogs about experiments / demos
+### Blogs about experiments / demos
 * [Blog of mr doob](http://mrdoob.com/blog) - very exciting experiments
 * [Blog of nihilogic](http://blog.nihilogic.dk/) - articles and experiments
 * [Blog of Ben Joffe](http://www.benjoffe.com/code/) - experiments
 
-###Forums/News for General Game Development (no javascript)
+### Forums/News for General Game Development (no javascript)
 * [Devmaster](http://devmaster.net/forums/)
 * [Tigsource](http://forums.tigsource.com/)
 * [Indiegamer](http://forums.indiegamer.com/)
@@ -121,8 +121,8 @@ because actionscript is very similar to javascript. you can definitely take away
 
 
 
-##<a name="game-talks">Game Talks</a>
-###Video / Audio
+## <a name="game-talks">Game Talks</a>
+### Video / Audio
 * [Lunch with Rob Hawkes: HTML5 Games](http://de.justin.tv/marakana_techtv/b/289978824) - by Rob Hawkes - Overview and lessons learned for html5 game programming
 * [Building a JavaScript-Based Game Engine for the Web](http://www.youtube.com/watch?v=_RRnyChxijA)
 * [Multiplayer Gaming with HTML5: Are We Ready?](http://vimeo.com/22549177)
@@ -130,7 +130,7 @@ because actionscript is very similar to javascript. you can definitely take away
 * [Angry Birds on HTML5](http://www.infoq.com/presentations/Angry-Birds-on-HTML5) - Challenges to port Angry Birds to Chrome/HTML5
 * [Lostcast](http://www.lostdecadegames.com/lostcast/) - Nice talks about game programming with Javascript. They also provide some very good links.
 
-###Presentations / Slides
+### Presentations / Slides
 * [5 tips for your html5 games](http://www.slideshare.net/ernesto.jimenez/5-tips-for-your-html5-games)
 * [10 tips to get started with html5 games](http://www.slideshare.net/KukoljGregory/10-tips-to-get-started-with-html5-games)
 * [HTML5 as a Game Console](http://www.slideshare.net/michalbu/html5-as-a-game-console) - by Michał Budzyński
@@ -139,7 +139,7 @@ because actionscript is very similar to javascript. you can definitely take away
 
 
 
-##<a name="game-design">Game Design</a>
+## <a name="game-design">Game Design</a>
 * [Gameprogrammingpatterns](http://gameprogrammingpatterns.com/)
 * http://www.gamasutra.com/view/feature/6362/redesigning_wild_ones_into_.php - Article about changing a game by 10 design decisions
 * [Making html5 Games Match your Screen](http://blog.gopherwoodstudios.com/2011/04/making-html5-games-match-your-screen.html)
@@ -147,7 +147,7 @@ because actionscript is very similar to javascript. you can definitely take away
 
 
 
-##<a name="#game-engines">Game Engines</a>
+## <a name="#game-engines">Game Engines</a>
 * [Bebraw's Game Engines List](https://github.com/bebraw/jswiki/wiki/Game-Engines) - Huge List about existing game engines with some filter criteria
 * [HTML5 Game Engine](http://html5gameengine.com/) - another small game engine list
 * [Game Engine Comparison](http://buildnewgames.com/game-engine-comparison/) - In this article craftyJs, LimeJs and ImpactJs are compared
@@ -155,7 +155,7 @@ because actionscript is very similar to javascript. you can definitely take away
 
 
 
-##<a name="game-services">Game Services</a>
+## <a name="game-services">Game Services</a>
 * [Scoreoid](http://www.scoreoid.net/) - service for scoring lists, leaderboards, in game analytics, ...
 * [Tapjs](http://www.tapjs.com/) - service for scoring lists, leaderboards, ...
 * [flexpi](http://flexpi.com/) - services for gaming - stats, ingame payment, social media
@@ -163,8 +163,8 @@ because actionscript is very similar to javascript. you can definitely take away
 * [Itch.io](http://itch.io/) - Game distribution platform for indie-developers.
 * [Clay.io](http://clay.io/devlanding) - service for leaderboards, achievements, data storage, analytics, payment processing, ...
 
-##<a name="javascript-games">Javascript Games</a>
-###Game Jams and competitions
+## <a name="javascript-games">Javascript Games</a>
+### Game Jams and competitions
 * [js1k contest](http://js1k.com/)
 * [js10k contest](http://10k.aneventapart.com/)
 * [js13k games](http://js13kgames.com/)
@@ -172,7 +172,7 @@ because actionscript is very similar to javascript. you can definitely take away
 * [FiMaRu](http://www.fightmagicrun.com)
 * [html5gamejam (2010)](http://www.html5gamejam.com/games)
 
-###Games with sourcecode
+### Games with sourcecode
 * [banditracer](http://www.banditracer.eu/) - micro machines like game written with gamejs framework
 * [runjumpbuild game](http://runjumpbuild.com/) / [source](https://github.com/jonoxia/platform-game) - online jump'n run editor, share levels with others
 * [html5-games](http://pinterest.com/netzzwerg/html5-games/) - great HTML5 games most time with an article and/or sourcecode
@@ -192,7 +192,7 @@ because actionscript is very similar to javascript. you can definitely take away
 * [Hextris](https://github.com/Hextris/hextris) - A fast paced puzzle game inspired by Tetris
 * [Pacman](https://github.com/daleharvey/pacman)
 
-###Here are some rememberable projects - but mostly with compressed code
+### Here are some rememberable projects - but mostly with compressed code
 * [canvasrider](http://canvasrider.com/) - it's fun
 * [freeciv](http://play.freeciv.org/) - Online Civilisation clone
 * [Legend of Zelda - Game Boy emulation](http://grantgalitz.org/get_the_hell_out/LegendOfZelda_Links_Awakening/)
@@ -201,18 +201,18 @@ because actionscript is very similar to javascript. you can definitely take away
 * [Top 20 HTML5 Games](http://www.netmagazine.com/features/top-20-html5-games)
 * [Gaming Mozillalabs](https://gaming.mozillalabs.com/)
 
-###HTML5 Games
+### HTML5 Games
 * [html5games](http://www.html5games.net/)
 * [launchgaming](http://www.lunchgaming.com/)
 
 
 
 
-##<a name="graphics-and-sound">Graphics and Sound</a>
-###Assets
+## <a name="graphics-and-sound">Graphics and Sound</a>
+### Assets
 * [Game Assets by Andre Schmitz](https://game-assets.zeef.com/andre.antonio.schmitz) - Nice list of ressources for game assets (gaphics, sounds, video, map editors...)
 
-###Graphic
+### Graphic
 * [Opengameart](http://opengameart.org/) - Free, legal art for open source game projects
 * [Free sprites](http://teh_pro.webs.com/sprites.htm)
 * [Game sprites](http://spriters-resource.com/)
@@ -229,7 +229,7 @@ because actionscript is very similar to javascript. you can definitely take away
 * [Sprite](http://www.kickstarter.com/projects/539087245/spriter/) - Animation tool - not tried, but looks awesome
 
 
-###Sound
+### Sound
 * [html5media](http://html5media.info/) - easy embedding of video and audio
 * [media.io](http://media.io/) - online audio converter
 * [nosoapradio.us](http://www.nosoapradio.us/) - Game music - free
@@ -242,13 +242,13 @@ because actionscript is very similar to javascript. you can definitely take away
 
 
 
-##<a name="tutorial">Learning / Tutorials (HTML5 / CSS / Javascript / Gaming)</a>
-###Landingpages
+## <a name="tutorial">Learning / Tutorials (HTML5 / CSS / Javascript / Gaming)</a>
+### Landingpages
 * [Learn HTML5 by Mozilla](https://developer.mozilla.org/en-US/learn/html5) - Great Landingpage
 * [Learn CSS by Mozilla](https://developer.mozilla.org/en-US/learn/css) - Great Landingpage
 * [Learn Javscript by Mozilla](https://developer.mozilla.org/en-US/learn/javascript) - Great Landingpage
 
-###Tutorials
+### Tutorials
 * [HTML5 Tutorials by HTML5 Rocks](http://www.html5rocks.com/tutorials/)
 * [HTML5 Tutorials by Game Development](http://www.html5gamedevelopment.org/) - Game Development News and Tutorials
 * [HTML5 Tutorials by HTML5Tutorial](http://www.html5tutorial.info) - Tutorials
@@ -275,22 +275,22 @@ because actionscript is very similar to javascript. you can definitely take away
 
 
 
-##<a name="standard-api">Standards / Specifications / API</a>
-###API
+## <a name="standard-api">Standards / Specifications / API</a>
+### API
 * [HTML5 Web API](https://wiki.mozilla.org/WebAPI)
 * [HTML5 Doctor](http://html5doctor.com/) - API
 * [HTML5 Canvas](http://canvas.quaese.de/) - API - german
 
-###Specification
+### Specification
 * [HTML5 specification](http://developers.whatwg.org/) - Standard - a readable HTML5 specification for web developers
 * [Javascript Reference by Mozilla](https://developer.mozilla.org/en/JavaScript)
 
-###Standards
+### Standards
 * [Front end development guidelines](http://taitems.github.com/Front-End-Development-Guidelines/) - best practises for front end development
 * [idiomatic.js](https://github.com/rwldrn/idiomatic.js) - Principles of Writing Consistent, Idiomatic JavaScript
 * [Whats new in a specification?](https://github.com/espadrine/New-In-A-Spec) - Overview of Changes in HTML5, ES5, ES6, DOM4, ...
 
-###Compatibility /Feature Detection
+### Compatibility /Feature Detection
 * [HTML5 Readyness](http://html5readiness.com/)
 * [HTML5 Please](http://html5please.com/)
 * [Caniuse](http://caniuse.com/) - Compatibility tables for support of HTML5, CSS3, SVG and more in desktop and mobile browsers.
@@ -299,8 +299,8 @@ because actionscript is very similar to javascript. you can definitely take away
 
 
 
-##<a name="html5-performance">HTML5 Performance</a>
-###Articles
+## <a name="html5-performance">HTML5 Performance</a>
+### Articles
 * [CSS tricks for canvas games](http://blog.safaribooksonline.com/2012/04/25/css-tricks-for-html5-canvas-games)
 * [Off-Screen Rendering (Render to Texture) with HTML5's Canvas Element](http://kaioa.com/node/103)
 * [Improving HTML5 Canvas Performance](http://www.html5rocks.com/en/tutorials/canvas/performance/)
@@ -309,7 +309,7 @@ because actionscript is very similar to javascript. you can definitely take away
 
 
 
-##<a name="html5-demos">HTML5 Demos</a>
+## <a name="html5-demos">HTML5 Demos</a>
 * [Chrome Experiments](http://www.chromeexperiments.com/)
 * [HTML5 Canvas Demos by Kevin Roast](http://www.kevs3d.co.uk/dev/index.html)
 * [Mozilla Demo Studio](https://developer.mozilla.org/en-US/demos/)
@@ -319,12 +319,12 @@ because actionscript is very similar to javascript. you can definitely take away
 * [Simple Physics](https://github.com/skadimoolam/SimplePhysics) - Examples of Simple Physics models that Game Developers can make use of. P.S This is still a WorkInProgress project but as time goes you can expect lots of great examples.
 
 
-##<a name="javascript-libraries">Javascript Libraries</a>
-###Library Lists
+## <a name="javascript-libraries">Javascript Libraries</a>
+### Library Lists
 * [microJs](http://microjs.com/) - list of micro frameworks
 * [jsdb.io](http://www.jsdb.io/) - list of the best javascript libraries
 
-###Libraries
+### Libraries
 * [modernizr](modernizr.com/) - testing on active html5 + css features in browsers
 * [stats.js](https://github.com/mrdoob/stats.js) - nice little tool to show fps stats
 * [sprite.js](https://github.com/batiste/sprite.js) - tool for sprite animation + nice demos
@@ -339,7 +339,7 @@ because actionscript is very similar to javascript. you can definitely take away
 
 
 
-##<a name="javascript-performance">Javascript Performance</a>
+## <a name="javascript-performance">Javascript Performance</a>
 * [JavaScript Function Call Profiling](http://ejohn.org/blog/function-call-profiling/) - Article, John Resig
 * [JSConf Talk: Games, Performance, TestSwarm](http://ejohn.org/blog/jsconf-talk-games-performance-testswarm/) - Video, John Resig
 * [jsPerf](http://jsperf.com/) - Javascript performance tests
@@ -356,14 +356,14 @@ because actionscript is very similar to javascript. you can definitely take away
 
 
 
-##<a name="javascript-talks">Javascript Talks</a>
+## <a name="javascript-talks">Javascript Talks</a>
 * [Talks of Fronteers 2010 conference](http://vimeo.com/15984466)
 * [Talks from Douglas Crockford](http://yuiblog.com/crockford/)
 * [YUI Theater](http://developer.yahoo.com/yui/theater/)
 
 
 
-##<a name="books">Books</a>
+## <a name="books">Books</a>
 * [Eloquentjavascript](http://eloquentjavascript.net/) - free eBook by Marijn Haverbeke
 * [DIVE INTO HTML5](http://diveintohtml5.org/) - free eBook by Mark Pilgrim
 * [Essential JavaScript Design Patterns For Beginners](http://www.addyosmani.com/resources/essentialjsdesignpatterns/book/) - free eBook by Addy Osmani
@@ -372,13 +372,13 @@ because actionscript is very similar to javascript. you can definitely take away
 * [OOP mit Javascript](http://www.peterkropff.de/site/javascript/oop.htm) - free eBook by Peter Kropff- german
 * [HTML5 Handbuch](http://webkompetenz.wikidot.com/docs:html-handbuch) - free eBook by Stefan Münz - german
 
-###Lists of free eBooks
+### Lists of free eBooks
 * [jsbooks](http://jsbooks.revolunet.com) — JavaScript
 * [free-programming-books](//github.com/vhf/free-programming-books) — Different themes and languages
 * [Learn How To Plan, Create, and Promote Games](http://www.lessmilk.com/content/lessmilk.pdf) - This book brifely introduce you to some inportent steps in Game Development.
 
-##Commercial books on HTML5 Game Development
-###General Game Development
+## Commercial books on HTML5 Game Development
+### General Game Development
 * [HTML5 Games Development by Example: Beginner’s Guide](http://shop.oreilly.com/product/9781849691260.do)
 * [HTML5 Game Development For Dummie](http://shop.oreilly.com/product/9781118074763.do)
 * [HTML5 Game Development Insights](http://www.apress.com/9781430266976)
@@ -389,7 +389,7 @@ because actionscript is very similar to javascript. you can definitely take away
 * [HTML5 Games Most Wanted](http://www.apress.com/9781430239789)
 * [Building JavaScript Games for Phones, Tablets, and Desktop](http://www.apress.com/9781430265382)
 
-###Books explaining a specific JS game engine
+### Books explaining a specific JS game engine
 * [HTML5 Game Development with ImpactJS](http://shop.oreilly.com/product/9781849694568.do)
 * [HTML5 Game Programming with enchant.js](http://www.apress.com/9781430247432)
 * [Beginning HTML5 Games with CreateJS](http://www.apress.com/9781430263401)
@@ -399,7 +399,7 @@ because actionscript is very similar to javascript. you can definitely take away
 * [WebGL Game Development](http://www.packtpub.com/webgl-game-development/book)
 
 
-###Other useful books on Game Development
+### Other useful books on Game Development
 * [Physics for JavaScript Games, Animation, and Simulations with HTML5 Canvas](http://www.apress.com/9781430263371)
 * [HTML5 Canvas, 2nd Edition](http://shop.oreilly.com/product/0636920026266.do)
 * [HTML5 Canvas Cookbook](http://shop.oreilly.com/product/9781849691369.do)
@@ -408,7 +408,7 @@ because actionscript is very similar to javascript. you can definitely take away
 * [AI for Game Developers](http://shop.oreilly.com/product/9780596005559.do)
 
 
-##<a name="email-newsletter">Email - Newsletter</a>
+## <a name="email-newsletter">Email - Newsletter</a>
 * [javascriptweekly](http://javascriptweekly.com/)
 * [html5weekly](http://html5weekly.com/)
 * [web-design-weekly](http://web-design-weekly.com/) 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
